### PR TITLE
fix: improve fallbacks

### DIFF
--- a/.changeset/shaggy-turkeys-repair.md
+++ b/.changeset/shaggy-turkeys-repair.md
@@ -1,0 +1,5 @@
+---
+"esm-env": patch
+---
+
+fix: address error in non-Vite bundlers when no conditions set

--- a/packages/esm-env/browser-fallback.js
+++ b/packages/esm-env/browser-fallback.js
@@ -1,0 +1,1 @@
+export default typeof window !== 'undefined';

--- a/packages/esm-env/dev-fallback.js
+++ b/packages/esm-env/dev-fallback.js
@@ -1,6 +1,6 @@
 const node_env = globalThis.process?.env?.NODE_ENV;
 if (!node_env) {
-	throw new Error('conditions should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.');
+	console.warn('If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.');
 }
 
-export default node_env !== 'production';
+export default node_env && !node_env.toLowerCase().includes('prod');

--- a/packages/esm-env/dev-fallback.js
+++ b/packages/esm-env/dev-fallback.js
@@ -1,13 +1,6 @@
-if (!import.meta.env) {
-	// changes to import.meta only apply to this file
-	// we have to do this to be able to directly access import.meta.env.DEV
-	// bunlder defines such as Vite will only replace import.meta.env.DEV and not import.meta.env?.DEV
-	// we also can't do import.meta.env && import.meta.env.DEV because that breaks tree-shaking
-	import.meta.env = {};
+const node_env = globalThis.process?.env?.NODE_ENV;
+if (!node_env) {
+	throw new Error('conditions should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.');
 }
 
-// import.meta.env.DEV can be replaced by a bundler define such as Vite does and the rest of this
-// expression can then be condensed down to a single boolean by the bundler if such a define is used
-// Otherwise, if there were no conditions defined and the build time replacement of import.meta.env.DEV
-// didn't happen then fallback to runtime check of process.env.NODE_ENV
-export default !!(import.meta.env.DEV ?? process?.env?.NODE_ENV !== 'production');
+export default node_env !== 'production';

--- a/packages/esm-env/package.json
+++ b/packages/esm-env/package.json
@@ -9,7 +9,6 @@
 	"homepage": "https://github.com/benmccann/esm-env",
 	"author": "Ben McCann (https://www.benmccann.com)",
 	"type": "module",
-	"sideEffects": false,
 	"exports": {
 		".": {
 			"types": "./index.d.ts",
@@ -17,7 +16,9 @@
 		},
 		"./browser": {
 			"browser": "./true.js",
-			"default": "./false.js"
+			"development": "./false.js",
+			"production": "./false.js",
+			"default": "./browser-fallback.js"
 		},
 		"./development": {
 			"development": "./true.js",


### PR DESCRIPTION
Vite defines conditions when bundling and the fallback is only hit when not bundling, so the `import.meta.env.DEV` doesn't do anything and can be removed

Conditions should be set during bundling. We can update `rollup-plugin-svelte` and `svelte-loader` to enforce that they are. Users should always have one of either `development` or `production` set. If neither are set, then we know something is wrong. We also know something is wrong in the svelte plugins if the the `svelte` condition doesn't get set

The fallbacks can't be tree-shaken, but can only be hit when not bundling in which case we don't need tree-shaking anyway