### PR TITLE
fix: correctly resolve `BROWSER` to false for edge runtimes, etc.

### DIFF
--- a/packages/esm-env/package.json
+++ b/packages/esm-env/package.json
@@ -15,6 +15,7 @@
 			"default": "./index.js"
 		},
 		"./browser": {
+			"workerd": "./false.js",
 			"browser": "./true.js",
 			"development": "./false.js",
 			"production": "./false.js",

--- a/packages/esm-env/package.json
+++ b/packages/esm-env/package.json
@@ -15,7 +15,7 @@
 			"default": "./index.js"
 		},
 		"./browser": {
-			"worker": "./false.js",
+			"workerd": "./false.js",
 			"browser": "./true.js",
 			"development": "./false.js",
 			"production": "./false.js",

--- a/packages/esm-env/package.json
+++ b/packages/esm-env/package.json
@@ -15,7 +15,7 @@
 			"default": "./index.js"
 		},
 		"./browser": {
-			"workerd": "./false.js",
+			"worker": "./false.js",
 			"browser": "./true.js",
 			"development": "./false.js",
 			"production": "./false.js",


### PR DESCRIPTION
It might be a common practice for edge runtimes (such as workerd) to resolve exports using the `browser` condition. This causes `BROWSER` to incorrectly resolve to `true` when it should really be `false`. This PR proposes adding a more specific condition for `workerd` so it doesn't fallback to `browser`. https://runtime-keys.proposal.wintercg.org/#workerd

For example, `@cloudflare/vite-plugin` and `wrangler` both use the `worker` condition followed by `browser`: https://github.com/cloudflare/workers-sdk/blob/7f1743a7b8409b399628f8ba645beeb9b1658171/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts#L128 so we would rather it resolved to `worker` (so that it doesn't resolve to client-only code in SvelteKit)

Other edge runtimes are Vercel https://runtime-keys.proposal.wintercg.org/#edge-light and Netlify https://runtime-keys.proposal.wintercg.org/#netlify

~EDIT: seems like `wrangler` users `workerd, worker, browser` but the Cloudflare Vite plugin only uses `workerd, browser`. Maybe we should use `worker` here instead of `workerd` similar to the `svelte` package and update the Vite plugin to resolve `worker` too.~ updated the Cloudflare Vite plugin to use the same conditions as wrangler